### PR TITLE
Be less verbose if particular shell is not found

### DIFF
--- a/tests/test-shell.sh
+++ b/tests/test-shell.sh
@@ -6,7 +6,7 @@ cd $BINDIR
 
 for MYSH in sh pdksh bash dash ash mksh
 do
-  MYSH=`which $MYSH` || continue
+  MYSH=`which $MYSH 2>/dev/null` || continue
 
   echo Using $MYSH
   $MYSH -se < test-real.sh


### PR DESCRIPTION
```
$ tests/test-shell.sh
Using /usr/bin/sh
BASH_VERSION='4.3.39(1)-release'
.. Testing ./simplify
.. OK
.. Testing ./mkblocks
.. OK
Using /usr/local/bin/pdksh
KSH_VERSION='@(#)PD KSH v5.2.14 99/07/13.2'
.. Testing ./simplify
.. OK
.. Testing ./mkblocks
.. OK
Using /usr/bin/bash
BASH_VERSION='4.3.39(1)-release'
.. Testing ./simplify
.. OK
.. Testing ./mkblocks
.. OK
Using /usr/bin/dash
.. Testing ./simplify
.. OK
.. Testing ./mkblocks
.. OK
Using /usr/bin/ash
.. Testing ./simplify
.. OK
.. Testing ./mkblocks
.. OK
Using /usr/bin/mksh
KSH_VERSION='@(#)MIRBSD KSH R50 2015/04/19'
.. Testing ./simplify
.. OK
.. Testing ./mkblocks
.. OK
```