### PR TITLE
Add check for DNS lookup restriction

### DIFF
--- a/despf.sh
+++ b/despf.sh
@@ -9,7 +9,10 @@ done
 
 domain=${1:-'orig.spf-tools.ml'}
 
+dig +short gnu.org NS || export NO_STRAIGHT_DNS=1
+
 findns() {
+  test -n "$NO_STRAIGHT_DNS" && { echo ""; return; }
   ns=""
   dd="$1"
   while

--- a/mkblocks.sh
+++ b/mkblocks.sh
@@ -14,14 +14,7 @@ delim="^"
 packet=257
 
 domain=${1:-'spf-tools.ml'}
-test -n "$2" || {
-  nameserver=`dig +short -t NS $domain | sed 1q`
-  alternate=`dig +short -t TXT $domain @$nameserver | \
-    grep "v=spf1" | grep -o "include:."`
-  alternate=`echo $alternate | cut -d: -f2 | sed 's/_//;s/s/_/'`
-  alternate="${alternate}spf"
-}
-prefix=${2:-"$alternate"}
+prefix=${2:-"spf"}
 incldomain="${prefix}X.$domain"
 footer="include:$incldomain $policy"
 let counter=1


### PR DESCRIPTION
DNS lookups will not be initiated to the authoritative nameservers
for the domain if such requests are blocked by firewall. The check
takes `dig timeout` (i.e. 5 seconds) if the requests are blocked.

Also simplify alternates mechanism in mkblocks.sh to not query
authoritative nameservers so that the only script which stays
affected by firewalling DNS is `despf.sh`.