### PR TITLE
findns: Filter out comments on stdout

### DIFF
--- a/include/despf.inc.sh
+++ b/include/despf.inc.sh
@@ -24,7 +24,7 @@ findns() {
       break 1
     }
   done
-  echo "$ns" | grep .
+  echo "$ns" | grep '^[^;]'
 }
 
 # printip <<EOF


### PR DESCRIPTION
This fixes #53 and is more general than
`grep -v "retrying in TCP mode"`