### PR TITLE
Cleanup Changes:

### DIFF
--- a/include/despf.inc.sh
+++ b/include/despf.inc.sh
@@ -69,7 +69,7 @@ parsepf() {
   host=$1
   myns=$(findns $host)
   mydig -t TXT $host @$myns | sed 's/^"//;s/"$//;s/" "//' \
-    | grep -E '^v=spf1\s+' | grep .
+    | grep -E '^v=spf1\s+'
 }
 
 # getem <includes>

--- a/normalize.sh
+++ b/normalize.sh
@@ -33,11 +33,10 @@ network() {
 while
   read i
 do
-  cidr=$(echo $i | cut -d: -f2)
+  cidr=$(echo $i | cut -d: -f2-)
   ipver=$(echo $i | cut -d: -f1)
   if [ $ipver = "ip4" ] ; then
     # check if is a CIDR
-    cidr=$(echo $i | cut -d: -f2 -)
     nm=$(echo $i | cut -s -d/ -f2)
     if [ "x$nm" = "x32" ] ; then
       echo $i


### PR DESCRIPTION
84b95a9 (Jan Sarenik, 33 seconds ago)
   normalize.sh: Get rid of redundant variable

0692c8f (Jan Sarenik, 63 seconds ago)
   despf.inc: Get rid of redundant grep