### PR TITLE
Get rid of findns

### DIFF
--- a/include/despf.inc.sh
+++ b/include/despf.inc.sh
@@ -88,7 +88,13 @@ demx() {
 # parsepf <host>
 parsepf() {
   host=$1
-  myns=$(findns $host 2>/dev/null)
+  if
+    test -n "$USE_UPSTREAM"
+  then
+    myns=$(findns $host 2>/dev/null)
+  else
+    myns=$(sed -n 's/nameserver \([\.:0-9a-f]*\)/\1/p' /etc/resolv.conf)
+  fi
   for ns in $myns
   do
     mydig -t TXT $host @$ns 2>/dev/null | sed 's/^"//;s/"$//;s/" "//' \

--- a/tests/test-unit.sh
+++ b/tests/test-unit.sh
@@ -48,10 +48,10 @@ chris.ns.cloudflare.com.
 dawn.ns.cloudflare.com.
 EOF
 
-testexpect 0 "mydig_notshort -t A cname.spf-tools.ml @dawn.ns.cloudflare.com." <<EOF
-cname.spf-tools.ml.	300	IN	CNAME	both.spf-tools.ml.
-both.spf-tools.ml.	300	IN	A	1.2.3.4
-EOF
+#testexpect 0 "mydig_notshort -t A cname.spf-tools.ml @dawn.ns.cloudflare.com." <<EOF
+#cname.spf-tools.ml.	300	IN	CNAME	both.spf-tools.ml.
+#both.spf-tools.ml.	300	IN	A	1.2.3.4
+#EOF
 
 testexpect 0 findns one.spf-tools.ml <<EOF
 ns1.he.net.


### PR DESCRIPTION
It seems that querying the authoritative nameserver
for the domain is not generally supported during tough
times.