### PR TITLE
AUTHORS: add @TheNoButton and @regnauld

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,5 @@ Thanks for feed-back also to:
   Steve Jenkins (@stevejenkins)
   IT Xpress (@itxpress)
   Jerome Lacoste (@lacestej)
+  James Macdonell (@TheNoButton)
+  Phil Regnauld (@regnauld)


### PR DESCRIPTION
I know this may look like a duplicity, but in long term
it allows this repository to remember people even without
GitHub. Until then, live long GitHub!