### PR TITLE
Change spf-tools.ml for energystan.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Simple tools for keeping the SPF TXT records tidy in order to fight
 
 Your original TXT record which causes more than 10 DNS lookups
 should be saved as an otherwise unused subdomain TXT record
-(e.g. `orig.spf-tools.ml`).
+(e.g. `orig.energystan.com`).
 
 Create a configuration file:
 
     cat > ~/.spf-toolsrc <<EOF
-    DOMAIN=spf-tools.ml
-    ORIG_SPF=orig.spf-tools.ml
+    DOMAIN=energystan.com
+    ORIG_SPF=orig.energystan.com
     DESPF_SKIP_DOMAINS=_spf.domain1.com:spf.domain2.org
     DNS_TIMEOUT=5
     EOF
@@ -152,8 +152,8 @@ To use this script, file `.spf-toolsrc` in `$HOME` directory should
 contain `TOKEN` and `EMAIL` variable definitions which are then used
 to connect to CloudFlare API. The file should also contain `DOMAIN`
 and `ORIG_SPF` variables which stand for the target SPF domain
-(e.g. `spf-tools.ml`) and original SPF record with includes
-(e.g. `orig.spf-tools.ml`) in order to use `runspftools.sh`
+(e.g. `energystan.com`) and original SPF record with includes
+(e.g. `orig.energystan.com`) in order to use `runspftools.sh`
 without modifying the script.
 
 Usage:
@@ -172,8 +172,8 @@ Usage:
 
 ## Links
 
- * https://dmarcian.com/spf-survey/spf-tools.ml
- * https://dmarcian.com/spf-survey/orig.spf-tools.ml
+ * https://dmarcian.com/spf-survey/spf.energystan.com
+ * https://dmarcian.com/spf-survey/orig.energystan.com
  * http://www.kitterman.com/spf/validate.html
  * http://serverfault.com/questions/584708
  * http://www.openspf.org/SPF_Record_Syntax

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -24,7 +24,7 @@
 #
 # Usage: ./despf.sh | ./simplify.sh | mkblocks.sh | \
 #          mkzoneent.sh | ./cloudflare.sh <domain>
-# E.g.: ... | ./cloudflare.sh spf-tools.ml
+# E.g.: ... | ./cloudflare.sh energystan.com
 
 for cmd in jq awk sed grep
 do
@@ -37,7 +37,7 @@ a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BINDIR=$(cd $a; pwd)
 test -n "$TOKEN" || { echo "TOKEN not set! Exiting." >&2; exit 1; }
 test -n "$EMAIL" || { echo "EMAIL not set! Exiting.">&2; exit 1; }
 
-DOMAIN=${1:-'spf-tools.ml'}
+DOMAIN=${1:-'energystan.com'}
 TTL=1 # 1 = auto
 APIURL="https://www.cloudflare.com/api_json.html"
 idsfile=$(mktemp /tmp/cloudflare-ids-XXXXXX)

--- a/compare.sh
+++ b/compare.sh
@@ -19,8 +19,8 @@
 #
 # Usage: ./compare.sh DOMAIN1 DOMAIN2
 
-domain1=${1:-'spf-tools.ml'}
-domain2=${2:-'orig.spf-tools.ml'}
+domain1=${1:-'spf.energystan.com'}
+domain2=${2:-'orig.energystan.com'}
 
 a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BINDIR=$(cd $a; pwd)
 PATH=$BINDIR:$PATH

--- a/despf.sh
+++ b/despf.sh
@@ -58,7 +58,7 @@ while getopts "t:s:h-" opt; do
 done
 shift $((OPTIND-1))
 
-domain=${*:-'orig.spf-tools.ml'}
+domain=${*:-'orig.energystan.com'}
 
 loopfile=$(mktemp /tmp/despf-loop-XXXXXXX)
 echo random-non-match-tdaoeinthaonetuhanotehu > $loopfile

--- a/genspfzone.sh
+++ b/genspfzone.sh
@@ -17,8 +17,8 @@
 #
 ##############################################################################
 
-ORIGDOMAIN=${1:-'orig.spf-tools.ml'}
-DOMAIN=${1:-'spf-tools.ml'}
+ORIGDOMAIN=${1:-'orig.energystan.com'}
+DOMAIN=${1:-'energystan.com'}
 
 a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BINDIR=$(cd $a; pwd)
 PATH=$BINDIR:$PATH

--- a/include/despf.inc.sh
+++ b/include/despf.inc.sh
@@ -72,7 +72,7 @@ printip() {
 }
 
 # dea <hostname> <cidr>
-# dea both.spf-tools.ml
+# dea both.energystan.com
 # 1.2.3.4
 # fec0::1
 dea() {
@@ -130,7 +130,7 @@ getem() {
 }
 
 # getamx host mech [mech [...]]
-# e.g. host="spf-tools.ml"
+# e.g. host="energystan.com"
 # e.g. mech="a a:gnu.org a:google.com/24 mx:gnu.org mx:jasan.tk/24"
 getamx() {
   host=$1

--- a/mkblocks.sh
+++ b/mkblocks.sh
@@ -26,7 +26,7 @@ do
 done
 
 # Default values
-domain="spf-tools.ml"
+domain="energystan.com"
 prefix="spf"
 policy="~all"
 delim="^"

--- a/tests/a24/cmd
+++ b/tests/a24/cmd
@@ -1,1 +1,1 @@
-$(which despf.sh) a24.spf-tools.ml
+$(which despf.sh) a24.energystan.com

--- a/tests/brokendns/cmd
+++ b/tests/brokendns/cmd
@@ -3,4 +3,4 @@ dig() {
   echo ";; connection timed out; no servers could be reached"
   return 9
 }
-findns orig.spf-tools.ml || true
+findns orig.energystan.com || true

--- a/tests/despf/cmd
+++ b/tests/despf/cmd
@@ -1,1 +1,1 @@
-$(which despf.sh) orig.spf-tools.ml
+$(which despf.sh) orig.energystan.com

--- a/tests/fix_32/cmd
+++ b/tests/fix_32/cmd
@@ -1,1 +1,1 @@
-$(which despf.sh) both-spf.spf-tools.ml
+$(which despf.sh) both-spf.energystan.com

--- a/tests/mx20/cmd
+++ b/tests/mx20/cmd
@@ -1,1 +1,1 @@
-$(which despf.sh) mx20.spf-tools.ml
+$(which despf.sh) mx20.energystan.com

--- a/tests/nospf/cmd
+++ b/tests/nospf/cmd
@@ -1,1 +1,1 @@
-! $(which despf.sh) nospf.spf-tools.ml
+! $(which despf.sh) nospf.energystan.com

--- a/tests/redirect/cmd
+++ b/tests/redirect/cmd
@@ -1,1 +1,1 @@
-$(which despf.sh) redir.spf-tools.ml
+$(which despf.sh) redir.energystan.com

--- a/tests/test-unit.sh
+++ b/tests/test-unit.sh
@@ -41,21 +41,21 @@ testexpect() {
   echo .... OK
 }
 
-testexpect 0 mydig -t TXT spf-tools.ml <<EOF
-"v=spf1 include:spf1.spf-tools.ml ~all"
+testexpect 0 mydig -t TXT spf.energystan.com <<EOF
+"v=spf1 include:spf1.energystan.com ~all"
 EOF
 
-testexpect 0 "mydig -t NS spf-tools.ml | sort" <<EOF
+testexpect 0 "mydig -t NS energystan.com | sort" <<EOF
 chris.ns.cloudflare.com.
 dawn.ns.cloudflare.com.
 EOF
 
-#testexpect 0 "mydig_notshort -t A cname.spf-tools.ml @dawn.ns.cloudflare.com." <<EOF
-#cname.spf-tools.ml.	300	IN	CNAME	both.spf-tools.ml.
-#both.spf-tools.ml.	300	IN	A	1.2.3.4
+#testexpect 0 "mydig_notshort -t A cname.energystan.com @dawn.ns.cloudflare.com." <<EOF
+#cname.energystan.com.	300	IN	CNAME	both.energystan.com.
+#both.energystan.com.	300	IN	A	1.2.3.4
 #EOF
 
-testexpect 0 findns one.spf-tools.ml <<EOF
+testexpect 0 findns one.energystan.com <<EOF
 ns1.he.net.
 EOF
 
@@ -80,32 +80,32 @@ ip4:1.2.3.4
 ip6:fec0::1
 EOF
 
-testexpect 0 dea both.spf-tools.ml <<EOF
+testexpect 0 dea both.energystan.com <<EOF
 ip4:1.2.3.4
 ip6:fec0::1
 EOF
 
-testexpect 0 dea cname.spf-tools.ml <<EOF
+testexpect 0 dea cname.energystan.com <<EOF
 ip4:1.2.3.4
 ip6:fec0::1
 EOF
 
-testexpect 0 dea cname.spf-tools.ml 24 <<EOF
+testexpect 0 dea cname.energystan.com 24 <<EOF
 ip4:1.2.3.4/24
 ip6:fec0::1/24
 EOF
 
-testexpect 0 demx mx.spf-tools.ml <<EOF
+testexpect 0 demx mx.energystan.com <<EOF
 ip4:5.6.7.8
 ip6:56:78::1
 EOF
 
-testexpect 0 demx mx.spf-tools.ml 24 <<EOF
+testexpect 0 demx mx.energystan.com 24 <<EOF
 ip4:5.6.7.8/24
 ip6:56:78::1/24
 EOF
 
-testexpect 0 demx spf-tools.ml 24 <<EOF
+testexpect 0 demx energystan.com 24 <<EOF
 ip4:122.103.250.12/24
 ip4:198.143.169.250/24
 ip4:42.3.81.21/24
@@ -114,23 +114,23 @@ ip4:66.37.25.72/24
 ip4:66.37.25.74/24
 EOF
 
-testexpect 0 getamx both-spf.spf-tools.ml a:both.spf-tools.ml <<EOF
+testexpect 0 getamx both-spf.energystan.com a:both.energystan.com <<EOF
 ip4:1.2.3.4
 ip6:fec0::1
 EOF
 
-testexpect 0 parsepf spf-tools.ml <<EOF
-v=spf1 include:spf1.spf-tools.ml ~all
+testexpect 0 parsepf spf.energystan.com <<EOF
+v=spf1 include:spf1.energystan.com ~all
 EOF
 
 # This tests the correct process of iteration
 # between different NS servers if one is not
 # responding
-testexpect 0 parsepf morens.spf-tools.ml <<EOF
-v=spf1 include:spf1.spf-tools.ml ~all
+testexpect 0 parsepf morens.energystan.com <<EOF
+v=spf1 include:spf1.energystan.com ~all
 EOF
 
-testexpect -n 1 parsepf mail.spf-tools.ml
+testexpect -n 1 parsepf mail.energystan.com
 
 testexpect -n 1 isincidrange.sh 74.86.241.250 199.122.123.192 32
 


### PR DESCRIPTION
On 05/23/2016 someone registered the domain spf-tools.ml
It was possible because I had it on a free plan. Lessons
learned, moving to energystan.com which I own.