### PR TITLE
Fix the usage of mktemp on Mac OS

### DIFF
--- a/tests/test-subdirs.sh
+++ b/tests/test-subdirs.sh
@@ -22,7 +22,7 @@ export PATH=$BINDIR/..:$PATH
 cd $BINDIR
 
 RUNSHELL=${1:-"/bin/sh"}
-out=$(mktemp)
+out=$(mktemp 2>/dev/null || mktemp -t 'spftools-test-subdir.XXXXXX')
 set | grep 'SH_VERSION=' >&2 || true
 for test in $(find . -mindepth 1 -maxdepth 1 -type d)
 do


### PR DESCRIPTION
The version of mktemp on Mac OS is not compatible with versions on
linux distributions. It requires either a template or a template prefix.

This change will supply a template prefix if running the plain mktemp fails
while executing the subdir tests.

http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x