### PR TITLE
Doc fixes for route53

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ documentation.
 Usage:
 
     ./despf.sh | ./simplify.sh | ./mkblocks.sh | \
-      ./mkzoneent.sh | ./route53.sh <hosted_zone_id>
+      ./route53.sh <hosted_zone_id>
 
 
 ### iprange.sh

--- a/route53.sh
+++ b/route53.sh
@@ -24,7 +24,7 @@
 # Requires AWS CLI from https://aws.amazon.com/cli/
 #
 # Usage: ./despf.sh | ./simplify.sh | mkblocks.sh | \
-#          mkzoneent.sh | ./route53.sh <hosted_zone_id>
+#          ./route53.sh <hosted_zone_id>
 # E.g.: ... | ./route53.sh ABCXYZEXAMPLE
 
 # The AWS CLI can be configured using ~/.aws/credentials or using


### PR DESCRIPTION
route53.sh should _not_ use mkzoneent.sh; fixes README and route53.sh docs.